### PR TITLE
chore: expose the mem variable as an executionOption

### DIFF
--- a/semi-empirical/parameterised-packages/se_pm3.json
+++ b/semi-empirical/parameterised-packages/se_pm3.json
@@ -40,14 +40,6 @@
         }
     },
     "parameterisation": {
-        "presets": {
-            "runtime": {
-                "args": [
-                    "--failSafeDelays=no",
-                    "--registerWorkflow=yes"
-                ]
-            }
-        },
         "executionOptions": {
             "variables": [
                 {
@@ -55,6 +47,9 @@
                 },
                 {
                     "name": "startIndex"
+                },
+                {
+                    "name":  "mem"
                 },
                 {
                     "name":  "gamess-walltime-minutes"
@@ -67,15 +62,27 @@
                 },
                 {
                     "name":  "gamess-gpus"
-                },
-                {
-                    "name":  "mem"
                 }
             ],
             "platform": [
                 "openshift",
                 "openshift-kubeflux",
                 "openshift-cpu"
+            ]
+        },
+        "presets": {
+            "environmentVariables": [],
+            "runtime": {
+                "args": [
+                    "--failSafeDelays=no",
+                    "--registerWorkflow=yes"
+                ]
+            },
+            "variables": [
+                {
+                    "name": "basis",
+                    "value": "GBASIS=PM3"
+                }
             ]
         }
     }

--- a/semi-empirical/parameterised-packages/se_pm3.json
+++ b/semi-empirical/parameterised-packages/se_pm3.json
@@ -6,7 +6,7 @@
                     "git": {
                         "location": {
                             "url": "https://github.com/st4sd/band-gap-gamess.git",
-                            "tag": "1.1.2"
+                            "tag": "1.1.3"
                         }
                     }
                 },
@@ -22,7 +22,7 @@
             "name": "band-gap-pm3-gamess-us",
             "tags": [
                 "latest",
-                "1.1.2"
+                "1.1.3"
             ],
             "maintainer": "https://github.com/michael-johnston",
             "description": "Uses the PM3 semi-empirical method to perform the geometry optimization and calculate the band-gap and related properties. The calculation is performed with GAMESS-US",
@@ -67,6 +67,9 @@
                 },
                 {
                     "name":  "gamess-gpus"
+                },
+                {
+                    "name":  "mem"
                 }
             ],
             "platform": [


### PR DESCRIPTION
## Context

As a workflow user I would like to configure the memory request of the GAMESS US component.

This PR :

- adds a `parameterisation.executionOption` for the `mem` variable whose default value is slightly more than `4Gi` (about 30 KiB more).
- sets `parameterisation.presets` entry for the `basis` variable to match the DFT variant parameterised package

## Checklist

Ensure your PR meets the following requirements:

- [ ] This PR is associated to one (or more) issues that are open
- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
