### PR TITLE
fix: ensure correct information in gamess input file

### DIFF
--- a/component-scripts/make_gamess_input_from_template_and_xyz.py
+++ b/component-scripts/make_gamess_input_from_template_and_xyz.py
@@ -153,7 +153,6 @@ def gamess_input_from_template(mol, gamess_xyz_data, name, template, indx=-1, sp
 
     log = logging.getLogger(__name__)
 
-    log.critical("HERE")
     mf = rdMolDescriptors.CalcMolFormula(mol)
     coordinates = gamess_xyz_data[["elements", "x", "y", "z"]]
     nuclear_charges = ["{:.1f}".format(round(float(w), 0)) for w in gamess_xyz_data["nuclear_charge"]]

--- a/component-scripts/make_gamess_input_from_template_and_xyz.py
+++ b/component-scripts/make_gamess_input_from_template_and_xyz.py
@@ -153,16 +153,18 @@ def gamess_input_from_template(mol, gamess_xyz_data, name, template, indx=-1, sp
 
     log = logging.getLogger(__name__)
 
+    log.critical("HERE")
     mf = rdMolDescriptors.CalcMolFormula(mol)
     coordinates = gamess_xyz_data[["elements", "x", "y", "z"]]
-    atomic_masses = ["{:.1f}".format(round(float(w), 0)) for w in gamess_xyz_data["masses"]]
-    log.info("Atomic mass: {}".format(atomic_masses))
-    coordinates.insert(loc=1, column="masses", value=atomic_masses)
+    nuclear_charges = ["{:.1f}".format(round(float(w), 0)) for w in gamess_xyz_data["nuclear_charge"]]
+    log.info("Nuclear charges (atomic numbers): {}".format(nuclear_charges))
+    coordinates.insert(loc=1, column="nuclear_charges", value=nuclear_charges)
     coords_csv = coordinates.to_csv(header=False, index=False, sep=" ")
 
     with open(template, "r") as fin:
         temp_data = [line.strip() for line in fin if line]
 
+    # Returns a list with [total_charge, spin, number_of_valence_electrons, number_of_electrons, radical]
     elec_data = count_electons(mol)
     if spin is not None:
         elec_data[1] = spin.strip()
@@ -307,10 +309,11 @@ def main():
     # Read xyz with custom xyz class
     xyz_reader = xyz_class.XYZParser()
     xyz_reader.parse_xyz_file(op.xyz_file)
-    gamess_xyz_data = xyz_reader.get_coordinates_and_symbols_with_atomic_weights()
+    gamess_xyz_data = xyz_reader.get_coordinates_and_symbols_with_nuclear_charges()
     log.info(gamess_xyz_data)
 
     # SDF file is used to pass molecule data so RDKit can be used to get common properties
+    log.critical(op.sdf)
     mol = Chem.rdmolfiles.MolFromMolFile(op.sdf)
 
     if mol is not None:

--- a/component-scripts/test_data/README.md
+++ b/component-scripts/test_data/README.md
@@ -1,0 +1,4 @@
+To test SMILES to GAMESS conversion
+
+python ../rdkit_smiles2coordinates.py --input input_smiles.csv --row 0
+python ../make_gamess_input_from_template_and_xyz.py -xf 0.xyz -g ../../dft/data-dft/input_molecule.txt -xp . -sf 0.sdf -sp . 

--- a/component-scripts/test_data/input_smiles.csv
+++ b/component-scripts/test_data/input_smiles.csv
@@ -1,0 +1,2 @@
+label, SMILES
+0, C1COCO1

--- a/component-scripts/xyz_class.py
+++ b/component-scripts/xyz_class.py
@@ -68,14 +68,17 @@ class XYZParser(object):
             log.debug("Number of atoms: {}\nDescription: {}".format(self.number_of_atoms, self.description))
             xyz_df_data = []
             xyz_df_with_masses_data = []
+            xyz_df_with_charges_data = []
             per_tab = Chem.rdchem.GetPeriodicTable()
             self.masses = []
+            self.nuclear_charge = []
             for ith, line in enumerate(xfin):
                 if line:
                     try:
                         elm, x, y, z = line.strip().split()
                         log.debug("Parsed: '{}' '{}' '{}' '{}'".format(elm, x, y, z))
                         self.masses.append(per_tab.GetAtomicWeight(elm))
+                        self.nuclear_charge.append(per_tab.GetAtomicNumber(elm))
                     except IndexError:
                         log.warning("Line {} should contain element x y z but index error encountered "
                                     "please check".format(ith + 2))
@@ -101,6 +104,8 @@ class XYZParser(object):
                     log.debug("Prepared: {} {} {} {}".format(elm, x, y, z))
                     xyz_df_data.append([elm, x, y, z])
                     xyz_df_with_masses_data.append([elm, self.masses[-1], x, y, z])
+                    xyz_df_with_charges_data.append([elm, self.nuclear_charge[-1], x, y, z])
+
 
         self.xyz_df = pd.DataFrame(data=xyz_df_data, columns=["elements", "x", "y", "z"])
         log.debug(self.xyz_df)
@@ -112,6 +117,7 @@ class XYZParser(object):
         log.debug(self.elements)
 
         self.xyz_with_masses_df = pd.DataFrame(data=xyz_df_with_masses_data, columns=["elements", "masses", "x", "y", "z"])
+        self.xyz_with_charges_df = pd.DataFrame(data=xyz_df_with_charges_data, columns=["elements", "nuclear_charge", "x", "y", "z"])
 
         log.info("xyz {} parsed successfully".format(xyz_file))
 
@@ -154,6 +160,13 @@ class XYZParser(object):
         :return:
         """
         return self.xyz_with_masses_df
+
+    def get_coordinates_and_symbols_with_nuclear_charges(self) -> pd.DataFrame:
+        """
+        Function to get the dataframe of symbols nuclear charges (atomic number) and coordinates
+        :return:
+        """
+        return self.xyz_with_charges_df
 
 
     def get_elements(self) -> list:


### PR DESCRIPTION
## Context

Fixes issues with GAMESS input file creation and provides example data and command lines to test the SMILES to GAMESS input conversion scripts.

Prior to this fix the DATA section of the GAMESS input file, which was for COORD=UNIQUE, contained atomic masses in the second column. However these should be atomic numbers/nuclear charges (see https://myweb.liu.edu/~nmatsuna/gamess/input/DATA.html)

One effect of this was that certain GAMESS checks would fail for a molecule which should actually pass e.g. checking number of electrons v charge

## Change list

- Write atomic numbers into GAMESS input file instead of masses (`make_gamess_input_from_template_and_xyz.py`)
- Retrieve atomic numbers when parsing XYZ data (xyz_class.py)
- Add data and command lines for testing the conversion scripts

## Checklist

Ensure your PR meets the following requirements:

- [ ] This PR is associated to one (or more) issues that are open
- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
